### PR TITLE
Fixing crash with the pipboy inventory and the pipboy light on at the same time.

### DIFF
--- a/data/Data/F4SE/Plugins/Buffout4.toml
+++ b/data/Data/F4SE/Plugins/Buffout4.toml
@@ -12,6 +12,7 @@ TESObjectREFRGetEncounterZone = true # Fixes a crash when looking up the encount
 UnalignedLoad = true                 # Fixes a crash related to SIMD intrinsics with an aligned move on unaligned memory
 UtilityShader = true                 # Fixes a crash when a shader can't be found for a given technique id
 WorkBenchSwap = true                 # Fixes a crash where you are scrapping or swapping many inventory items in the workbench
+PipboyLightInvFix = true             # Fixes a crash when you have the pipboy light on and checking inventory
 
 [Patches]
 Achievements = true               # Enables achievements on modded saves
@@ -21,7 +22,7 @@ BSTextureStreamerLocalHeap = true # Replaces the texture streamer's local heap w
 HavokMemorySystem = true          # Replaces the havok memory system with os allocators
 INISettingCollection = true       # Massively improves startup times for large load orders by optimizing ini setting loading
 InputSwitch = false               # Automatically swaps inputs between kb+m/controller
-MaxStdIO = -1                     # Replaces the maximum stdio handles. Default 512, max 8192 https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmaxstdio?view=msvc-170
+MaxStdIO = 2048                   # Replaces the maximum stdio handles. Default 512, max 8192 https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmaxstdio?view=msvc-170
 MemoryManager = true              # Replaces the global memory manager with os allocators
 MemoryManagerDebug = false        # Enables debug tracing to determine faulting modules
 ScaleformAllocator = true         # Replaces the scaleform memory allocator with os allocators

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,7 @@ set(SOURCE_FILES
 	"${SOURCE_DIR}/Fixes/MagicEffectApplyEventFix.h"
 	"${SOURCE_DIR}/Fixes/MovementPlannerFix.h"
 	"${SOURCE_DIR}/Fixes/PackageAllocateLocationFix.h"
+	"${SOURCE_DIR}/Fixes/PipboyLightInvFix.h"
 	"${SOURCE_DIR}/Fixes/SafeExitFix.h"
 	"${SOURCE_DIR}/Fixes/TESObjectREFRGetEncounterZoneFix.h"
 	"${SOURCE_DIR}/Fixes/UnalignedLoadFix.h"

--- a/src/Fixes/Fixes.cpp
+++ b/src/Fixes/Fixes.cpp
@@ -75,6 +75,10 @@ namespace Fixes
 		if (*Settings::UtilityShader) {
 			UtilityShaderFix::Install();
 		}
+
+		if (*Settings::PipboyLightInvFix) {
+			PipboyLightInvFix::Install();
+		}
 #endif
 	}
 }

--- a/src/Fixes/Fixes.cpp
+++ b/src/Fixes/Fixes.cpp
@@ -13,6 +13,7 @@
 #include "Fixes/UnalignedLoadFix.h"
 #include "Fixes/UtilityShaderFix.h"
 #include "Fixes/WorkBenchSwapFix.h"
+#include "Fixes/PipboyLightInvFix.h"
 
 namespace Fixes
 {
@@ -61,7 +62,12 @@ namespace Fixes
 #ifdef FALLOUTVR
 		if (*Settings::WorkBenchSwap) {
 			WorkBenchSwapFix::Install();
+		}	
+		
+		if (*Settings::PipboyLightInvFix) {
+			PipboyLightInvFix::Install();
 		}
+
 #endif
 	}
 
@@ -76,9 +82,6 @@ namespace Fixes
 			UtilityShaderFix::Install();
 		}
 
-		if (*Settings::PipboyLightInvFix) {
-			PipboyLightInvFix::Install();
-		}
 #endif
 	}
 }

--- a/src/Fixes/PipboyLightInvFix.h
+++ b/src/Fixes/PipboyLightInvFix.h
@@ -1,0 +1,39 @@
+#pragma once
+
+namespace Fixes::PipboyLightInvFix
+{
+	namespace detail
+	{
+		struct Patch : Xbyak::CodeGenerator
+		{
+			explicit Patch(std::uintptr_t a_dest)
+			{
+				Xbyak::Label retLab;
+
+				and_(dword[rdi + 0x4], 0xFFFFFFF);
+				mov(rcx, 1);
+				jmp(ptr[rip + retLab]);
+
+				L(retLab);
+				dq(a_dest);
+			}
+		};
+
+	}
+
+	inline void Install()
+	{
+		REL::Relocation<std::uintptr_t> target{ REL::Offset(0xf2d240), 0x48 };
+		REL::Relocation<std::uintptr_t> resume{ REL::Offset(0xf2d240), 0x4D };
+
+		detail::Patch p{ resume.address() };
+		p.ready();
+
+		auto& trampoline = F4SE::GetTrampoline();
+		trampoline.write_branch<5>(
+			target.address(),
+			trampoline.allocate(p));
+
+		logger::info("installed PipboyLightInvFix Swap fix"sv);
+	}
+}

--- a/src/Fixes/PipboyLightInvFix.h
+++ b/src/Fixes/PipboyLightInvFix.h
@@ -6,16 +6,25 @@ namespace Fixes::PipboyLightInvFix
 	{
 		struct Patch : Xbyak::CodeGenerator
 		{
-			explicit Patch(std::uintptr_t a_dest)
+			explicit Patch(std::uintptr_t a_dest, std::uintptr_t a_rtn)
 			{
+				Xbyak::Label contLab;
 				Xbyak::Label retLab;
 
-				and_(dword[rdi + 0x4], 0xFFFFFFF);
-				mov(rcx, 1);
+				test(rbx, rbx);
+				jz("returnFunc");
+				mov(rdx, rax);
+				movss(xmm2, dword[rax + 0xa0]);
+				jmp(ptr[rip + contLab]);
+
+				L("returnFunc");
 				jmp(ptr[rip + retLab]);
 
-				L(retLab);
+				L(contLab);
 				dq(a_dest);
+
+				L(retLab);
+				dq(a_rtn);
 			}
 		};
 
@@ -23,10 +32,15 @@ namespace Fixes::PipboyLightInvFix
 
 	inline void Install()
 	{
-		REL::Relocation<std::uintptr_t> target{ REL::Offset(0xf2d240), 0x48 };
-		REL::Relocation<std::uintptr_t> resume{ REL::Offset(0xf2d240), 0x4D };
+		REL::Relocation<std::uintptr_t> target{ REL::Offset(0xf2d240).address() + 0xD28 };
+		REL::Relocation<std::uintptr_t> resume{ REL::Offset(0xf2d240).address() + 0xD33 };
+		REL::Relocation<std::uintptr_t> returnAddr{ REL::Offset(0xf2d240).address() + 0xE16 };
 
-		detail::Patch p{ resume.address() };
+		for (std::size_t i = 0; i < 11; i++) {
+			REL::safe_write(target.address() + i, std::uint32_t{ 0x90 });
+		}
+
+		detail::Patch p{ resume.address(), returnAddr.address() };
 		p.ready();
 
 		auto& trampoline = F4SE::GetTrampoline();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -58,6 +58,7 @@ namespace Settings
 	MAKE_SETTING(bSetting, "Fixes", UnalignedLoad, true);
 	MAKE_SETTING(bSetting, "Fixes", UtilityShader, true);
 	MAKE_SETTING(bSetting, "Fixes", WorkBenchSwap, true);
+	MAKE_SETTING(bSetting, "Fixes", PipboyLightInvFix, true);
 
 	MAKE_SETTING(bSetting, "Patches", Achievements, true);
 	MAKE_SETTING(bSetting, "Patches", BSMTAManager, true);
@@ -122,6 +123,7 @@ namespace Settings
 		LOAD(UnalignedLoad);
 		LOAD(UtilityShader);
 		LOAD(WorkBenchSwap);
+		LOAD(PipboyLightInvFix);
 
 		LOAD(Achievements);
 		LOAD(BSMTAManager);


### PR DESCRIPTION
     140f2df5c e8 3f 95      CALL      TESObjectLIGH::GetLightAttachNode(NiAVObj  undefined TESObjectLIGH::Get
               3d ff
     140f2df61 48 8b 8b      MOV       param_3,qword ptr [RBX + 0x10b0]
               b0 10 00 
               00

Basically RBX + 0x10b0 sometimes can be null which causes crash.   fix is to implement null pointer checker and exit function if null