### PR TITLE
build: Fix build issues

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -63,14 +63,41 @@
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /external:W0"
       },
+      "hidden": true,
+      "name": "vs2022-flags"
+    },
+    {
       "generator": "Visual Studio 17 2022",
       "inherits": [
+        "vs2022-flags",
         "cmake-dev",
         "vcpkg",
         "windows"
       ],
       "name": "vs2022-windows-vcpkg",
       "toolset": "v143"
+    },
+    {
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "cl"
+      },
+      "architecture": {
+        "strategy": "external",
+        "value": "x64"
+      },
+      "toolset": {
+        "strategy": "external",
+        "value": "v143,host=x64"
+      },
+      "generator": "Ninja",
+      "inherits": [
+        "vs2022-flags",
+        "cmake-dev",
+        "vcpkg",
+        "windows"
+      ],
+      "description": "If you are running CMake from the command line and not from an IDE, make sure to run 'vcvars64.bat' first. The default installed location of this is 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat'.",
+      "name": "vs2022-ninja-windows-vcpkg"
     }
   ]
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -352,6 +352,7 @@ add_custom_target(build-time-make-directory ALL
 )
 
 message("Copying mod into ${ZIP_DIR}.")
+file(MAKE_DIRECTORY "${ZIP_DIR}/F4SE/Plugins/")
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${PROJECT_NAME}> "${ZIP_DIR}/F4SE/Plugins/"
 )

--- a/src/Crash/CrashHandler.cpp
+++ b/src/Crash/CrashHandler.cpp
@@ -107,7 +107,7 @@ namespace Crash
 		for (std::size_t i = 0; i < _frames.size(); ++i) {
 			const auto mod = moduleStack[i];
 			const auto& frame = _frames[i];
-			a_log.critical(format, i, reinterpret_cast<std::uintptr_t>(frame.address()), (mod ? mod->name() : ""sv),
+			a_log.critical(fmt::runtime(format), i, reinterpret_cast<std::uintptr_t>(frame.address()), (mod ? mod->name() : ""sv),
 				(mod ? mod->frame_info(frame) : ""s));
 		}
 	}
@@ -119,7 +119,7 @@ namespace Crash
 		const auto format = "\t[{:>"s + get_size_string(_stacktrace.size()) + "}] 0x{:X}"s;
 
 		for (std::size_t i = 0; i < _stacktrace.size(); ++i) {
-			a_log.critical(format, i, reinterpret_cast<std::uintptr_t>(_stacktrace[i].address()));
+			a_log.critical(fmt::runtime(format), i, reinterpret_cast<std::uintptr_t>(_stacktrace[i].address()));
 		}
 	}
 
@@ -283,7 +283,7 @@ namespace Crash
 			}();
 
 			for (const auto& mod : a_modules) {
-				a_log.critical(format, mod->name(), mod->address());
+				a_log.critical(fmt::runtime(format), mod->name(), mod->address());
 			}
 		}
 
@@ -299,7 +299,7 @@ namespace Crash
 						return "\t[{:>02X}]{:"s + (!smallfiles.empty() ? "5"s : "1"s) + "}{}"s;
 					}();
 					for (const auto file : files) {
-						a_log.critical(fileFormat, file->GetCompileIndex(), "", file->GetFilename());
+						a_log.critical(fmt::runtime(fileFormat), file->GetCompileIndex(), "", file->GetFilename());
 					}
 					for (const auto file : smallfiles) {
 						a_log.critical("\t[FE:{:>03X}] {}"sv, file->GetSmallFileCompileIndex(), file->GetFilename());
@@ -308,7 +308,7 @@ namespace Crash
 					auto& files = datahandler->files;
 					const auto fileFormat = [&]() { return "\t[{:>02X}]{:"s + "}{}"s; }();
 					for (const auto file : files) {
-						a_log.critical(fileFormat, file->GetCompileIndex(), "", file->GetFilename());
+						a_log.critical(fmt::runtime(fileFormat), file->GetCompileIndex(), "", file->GetFilename());
 					}
 				}
 			}
@@ -398,7 +398,7 @@ namespace Crash
 					const auto analysis = Introspection::analyze_data(
 						stack.subspan(off, std::min<std::size_t>(stack.size() - off, blockSize)), a_modules);
 					for (const auto& data : analysis) {
-						a_log.critical(format, idx * sizeof(std::size_t), stack[idx], data);
+						a_log.critical(fmt::runtime(format), idx * sizeof(std::size_t), stack[idx], data);
 						++idx;
 					}
 				}

--- a/src/Crash/Introspection/Introspection.cpp
+++ b/src/Crash/Introspection/Introspection.cpp
@@ -315,7 +315,7 @@ namespace Crash::Introspection::F4
 						auto sourcefile = sourcefiles->data()[index];
 						filesString = filesString.empty() ? fmt::format("{}"sv,
 																sourcefile->GetFilename().data()) :
-                                                            fmt::format("{} -> {}"sv,
+						                                    fmt::format("{} -> {}"sv,
 																filesString, sourcefile->GetFilename().data());
 					}
 					a_results.emplace_back(
@@ -690,11 +690,11 @@ namespace Crash::Introspection::F4
 					auto traceFormatString = "{:\t>{}}[{}].{}.{}() - \"{}\" Line {}\n";  // Same format in Papyrus logs
 					std::string lineTrace = "";
 					if (function.get()->GetIsNative()) {
-						lineTrace = fmt::format(traceFormatString, "", tab_depth, objectInstanceString, functionObjecTypeName, functionName, sourceFileName, "?"sv);
+						lineTrace = fmt::format(fmt::runtime(traceFormatString), "", tab_depth, objectInstanceString, functionObjecTypeName, functionName, sourceFileName, "?"sv);
 					} else {
 						std::uint32_t lineNumber;
 						function.get()->TranslateIPToLineNumber(currentStackFrame->ip, lineNumber);
-						lineTrace = fmt::format(traceFormatString, "", tab_depth, objectInstanceString, functionObjecTypeName, functionName, sourceFileName, std::to_string(lineNumber));
+						lineTrace = fmt::format(fmt::runtime(traceFormatString), "", tab_depth, objectInstanceString, functionObjecTypeName, functionName, sourceFileName, std::to_string(lineNumber));
 					}
 					stackTrace = stackTrace + lineTrace;
 					currentStackFrame = currentStackFrame->previousFrame;
@@ -742,8 +742,8 @@ namespace Crash::Introspection
 			Integer(std::size_t a_value) noexcept :
 				_value(a_value),
 				name_string(a_value >> 63 ?
-                                fmt::format("(size_t) [uint: {} int: {}]"s, _value, static_cast<std::make_signed_t<size_t>>(_value)) :
-                                fmt::format("(size_t) [{}]"s, _value))
+								fmt::format(fmt::runtime("(size_t) [uint: {} int: {}]"s), _value, static_cast<std::make_signed_t<size_t>>(_value)) :
+								fmt::format(fmt::runtime("(size_t) [{}]"s), _value))
 			{
 			}
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -32,7 +32,7 @@
     "zycore",
     "zydis"
   ],
-  "builtin-baseline": "d8aa5e022c45dd527302f01cc5cf39c177f58a4f",
+  "builtin-baseline": "36fb23307e10cc6ffcec566c46c4bb3f567c82c6",
   "overrides": [
     {
       "name": "fmt",


### PR DESCRIPTION
### Fix vcpkg install

The baseline pointed to a commit on your fork; I changed it to the commit on mainline right before.

I don't believe it is necessary to use your fork now; comparing your fork with mainline, it seems that the fixes that you cherry-picked for zydis are in mainline now.

### Fix mod copy into zip dir during build
The build was failing because ${ZIP_DIR}/F4SE/Plugins/ didn't exist before the copy

### add vs2022-ninja-windows-vcpkg preset

This lets us use ninja as a generator instead of MSBuild
This works out of the box with CLion, visual studio, and vscode, but if run from the command line, you have to run vcvars64.bat first. I've added those instructions to the description


### Fix compile on fmt v9

fmt v9 requires you to specify runtime-determined format strings with fmt::runtime()
This change is backwards compatible with v8


