### PR TITLE
ci: update spdlog version in vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -23,7 +23,10 @@
     "rsm-binary-io",
     "rsm-mmio",
     "srell",
-    "spdlog",
+    {
+      "name": "spdlog",
+      "version>=": "1.15.0"
+    },
     "tbb",
     "tomlplusplus",
     "xbyak",


### PR DESCRIPTION
was seeing linking error 

C:\repos\Buffout4\build\spdlog.lib(async.cpp.obj) : error LNK2019: unresolved external symbol _Cnd_timedwait_for_unchecked

Forcing newer version of spdlog more recent than the baseline fixed.