### PR TITLE
fix: bump CommonLibF4 to fix C++23 aligned_storage deprecation

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -14,7 +14,7 @@ on:
       # Dependencies
       - 'vcpkg.json'
       - '.gitmodules'
-      - 'extern/**'
+      - 'external/**'
       # Build scripts
       - 'scripts/**'
       # CI workflows that affect build


### PR DESCRIPTION
## Problem

The `1.38.0` [Semantic Release run](https://github.com/alandtse/Buffout4/actions/runs/26795943517) failed at the **Build Release** step, so the **Upload to Nexus Mods** step never ran (it's gated on a successful build).

Root cause: GitHub's runner image updated MSVC's STL, which now emits **C4996 / STL4034** for the deprecated `std::aligned_storage_t` used in CommonLibF4's `RE/msvc/functional.h`. Buffout4 sets `/WX` globally in `CMakePresets.json`, promoting it to a hard error:

```
RE\msvc\functional.h(42,8): error C2220: the following warning is treated as an error
warning C4996: 'std::aligned_storage_t': warning STL4034: ... deprecated in C++23.
```

This is not related to the Nexus workflow migration (#36) — that step is fine; the build simply never got there.

## Fix

Bump the `CommonLibF4` submodule to include alandtse/CommonLibF4#43, which replaces `std::aligned_storage_t<3 * sizeof(void*), alignof(long double)>` with the MSVC-recommended `alignas(long double) std::byte _storage[3 * sizeof(void*)]`. Layout is byte-identical (24 bytes, align 8, `_fn` at `0x18`), so the ABI mirror of `std::_Func_class` is unchanged. No Buffout4 source changes required.

## Verification

- alandtse/CommonLibF4#43 CI: all 6 `windows` configs green (release/debug × all/flat/vr).
- Local MSVC (`/std:c++latest /W4 /WX`): old form reproduced the exact `C2220/C4996` error; new form compiles clean and passes `static_assert`s confirming identical size/offset/alignment.

## Bonus: ESL support

The bumped CommonLibF4 carries the ESL-aware FormID handling (`smallFileCompileIndex` / `0xFE` light-plugin decoding). Buffout4 already calls these APIs (e.g. the `[FE:xxx]` plugin lines in crash logs), so this release ships correct ESL attribution with no further changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)