### PR TITLE
fix(VR): PipboyLightInvFix startup crash

### DIFF
--- a/src/Fixes/PipboyLightInvFix.h
+++ b/src/Fixes/PipboyLightInvFix.h
@@ -14,7 +14,7 @@ namespace Fixes::PipboyLightInvFix
 
 				test(rbx, rbx);
 				jz("returnFunc");
-				mov(rcx, dword[rbx + a_rbx_offset]);
+				mov(rcx, qword[rbx + a_rbx_offset]);
 				test(rcx, rcx);
 				jz("returnFunc");
 				test(rax, rax);


### PR DESCRIPTION
PipboyLightInvFix generated `mov rcx, dword[...]` — a 64-bit register with a 32-bit operand. The xbyak in 1.38.x rejects the size mismatch and throws in `Install`, crashing at launch.

The original engine instruction is a 7-byte 64-bit load (`mov rcx, qword[rbx+disp32]`), so the operand should be `qword`. No behavior change on F4/NG; fixes the VR startup crash on 1.38.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with Pipboy light inventory handling affecting memory data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->