### PR TITLE
ci: enable vcpkg binary caching

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -51,6 +51,9 @@ jobs:
     runs-on: windows-latest
     if: github.repository_owner == 'alandtse'
 
+    env:
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -78,6 +81,15 @@ jobs:
 
       - name: Prints output of run-vcpkg's action
         run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}'"
+
+      # x-gha reads the Actions cache endpoint from these two variables, which GitHub
+      # only exposes to the github-script runtime — re-export them so vcpkg sees them.
+      - name: Enable vcpkg GitHub Actions binary cache
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Run CMake with vcpkg.json manifest
         uses: lukka/run-cmake@v10


### PR DESCRIPTION
## What

Enables GitHub Actions binary caching for vcpkg in the reusable build workflow (`.github/workflows/build-reusable.yml`), so CI restores prebuilt dependency `.libs` from the Actions cache instead of recompiling every vcpkg dependency on every run.

## Why

The build uses `lukka/run-vcpkg@v11` + `lukka/run-cmake@v10` (cmake does the manifest install), with no binary-source configuration. Every CI run rebuilds all vcpkg deps from source, which is slow and wasteful.

## How

- Added a job-level `env` block setting `VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"` so vcpkg reads from and writes to the GitHub Actions cache backend.
- Added a `actions/github-script@v7` step immediately before the `run-cmake` step that re-exports `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN`. GitHub only exposes these to the github-script runtime, so they must be re-exported as environment variables for vcpkg's `x-gha` provider to discover the cache endpoint.

YAML validated locally with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)