### PR TITLE
fix(vr): prevent EscapeFreeze lock handoff deadlock

### DIFF
--- a/src/Fixes/EscapeFreeze.h
+++ b/src/Fixes/EscapeFreeze.h
@@ -55,8 +55,8 @@ namespace Fixes::EscapeFreeze
 		}
 
 		// members
-		std::atomic<std::uint32_t> _owningThread{ 0 };        // 0
-		std::atomic<std::uint32_t> _lockCount{ 0 };           // 4
+		std::atomic<std::uint32_t> _owningThread{ 0 };  // 0
+		std::atomic<std::uint32_t> _lockCount{ 0 };     // 4
 	};
 
 	static std::vector<Spinlock*> spinlocks{};

--- a/src/Fixes/EscapeFreeze.h
+++ b/src/Fixes/EscapeFreeze.h
@@ -1,6 +1,6 @@
 #pragma once
-// based on details from https://www.nexusmods.com/fallout4/mods/75216?tab=description
-// essentially, this will manually reset a lock on a threshold of 8.
+// Based on details from https://www.nexusmods.com/fallout4/mods/75216?tab=description.
+// Replaces the problematic engine lock used by the VR VATS path.
 #include <atomic>
 
 namespace Fixes::EscapeFreeze
@@ -34,24 +34,29 @@ namespace Fixes::EscapeFreeze
 	public:
 		void lock()
 		{
-			_lockCount++;
+			_lockCount.fetch_add(1, std::memory_order_relaxed);
 			while (atomic_flag.test_and_set(std::memory_order_acquire)) {
 				Sleep(1);
 			}
-			_owningThread = REX::W32::GetCurrentThreadId();
+			_owningThread.store(REX::W32::GetCurrentThreadId(), std::memory_order_relaxed);
 		}
 		void unlock()
 		{
-			if (_owningThread == REX::W32::GetCurrentThreadId()) {
+			if (_owningThread.load(std::memory_order_relaxed) == REX::W32::GetCurrentThreadId()) {
+				// Publish the lock as available only after all owner bookkeeping is
+				// complete. Clearing the flag first allowed a waiter to acquire it
+				// and publish its thread ID, after which the previous owner could
+				// overwrite that ID with zero. The new owner then refused to
+				// unlock, permanently stalling every subsequent caller.
+				_lockCount.fetch_sub(1, std::memory_order_relaxed);
+				_owningThread.store(0, std::memory_order_relaxed);
 				atomic_flag.clear(std::memory_order_release);
-				_owningThread = 0;
-				_lockCount--;
 			}
 		}
 
 		// members
 		std::atomic<std::uint32_t> _owningThread{ 0 };        // 0
-		volatile std::atomic<std::uint32_t> _lockCount{ 0 };  // 4
+		std::atomic<std::uint32_t> _lockCount{ 0 };           // 4
 	};
 
 	static std::vector<Spinlock*> spinlocks{};


### PR DESCRIPTION
This fixes the infamous death reload bug on F4VR which was introduced after version 1.15 when EscapeFreezeFix was added: after dying, the game would become unresponsive.

`Spinlock::unlock()` released the lock before finishing its owner bookkeeping: it cleared the atomic flag first, then zeroed `_owningThread` and decremented the count. In that window a waiter could acquire the lock and publish its own thread ID — which the previous owner then overwrote with zero. The new owner's `unlock()` no longer matched `GetCurrentThreadId()`, so the flag was never cleared again and every subsequent caller spun forever.

This reorders `unlock()` so the owner/count bookkeeping completes before the flag is released, makes the memory orderings explicit, and drops the redundant `volatile` on the atomic counter.

The fix has been validated in-game by a tester at a spot where the bug would reliably occur. EscapeFreeze is VR-only (`Fixes.cpp` gates it on `REL::Module::IsVR()`), so F4 OG/NG are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock handling to prevent deadlocks and stalls during concurrent operations.
  * Strengthened thread ownership tracking and synchronization for more reliable behavior.
  * Updated internal lock-count management for safer atomic operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->