### PR TITLE
ci: pin Windows build to windows-2022 runner image

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   build:
     name: Build on Windows
-    runs-on: windows-latest
+    runs-on: windows-2022
     if: github.repository_owner == 'alandtse'
 
     env:


### PR DESCRIPTION
All CI builds currently fail at CMake configure (first seen on #42):

```
CMake Error at CMakeLists.txt:5 (project):
  Generator "Visual Studio 17 2022" could not find any instance of Visual Studio.
```

GitHub rolled `windows-latest` to `windows-2025-vs2026`, which ships Visual Studio 2026 and no longer includes VS 2022, so the `vs2022-windows-vcpkg` preset can't configure. The last green `Test Build` was June 3 (#40), on the old image.

This pins the build job to `windows-2022` — still a supported image (it's what CommonLibF4's CI runs on) — keeping the existing presets and the v143 toolchain that all releases so far were built with.