### PR TITLE
ci: fix Windows CI with Ninja generator

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -10,39 +10,39 @@ on:
   workflow_call:
     inputs:
       configure-preset:
-        description: 'CMake configure preset'
+        description: "CMake configure preset"
         type: string
         required: false
-        default: 'vs2022-ninja-windows-vcpkg'
+        default: "vs2022-ninja-windows-vcpkg"
       build-preset:
-        description: 'CMake build preset'
+        description: "CMake build preset"
         type: string
         required: false
-        default: 'Release-Ninja'
+        default: "Release-Ninja"
       version:
-        description: 'Version string for the build'
+        description: "Version string for the build"
         type: string
         required: false
-        default: ''
+        default: ""
       upload-artifact:
-        description: 'Whether to upload build artifact'
+        description: "Whether to upload build artifact"
         type: boolean
         required: false
         default: false
       ref:
-        description: 'Git ref to checkout'
+        description: "Git ref to checkout"
         type: string
         required: false
-        default: ''
+        default: ""
     outputs:
       artifact-name:
-        description: 'Name of the uploaded artifact'
+        description: "Name of the uploaded artifact"
         value: ${{ jobs.build.outputs.artifact-name }}
       artifact-path:
-        description: 'Path to the built artifact'
+        description: "Path to the built artifact"
         value: ${{ jobs.build.outputs.artifact-path }}
       normalized_version:
-        description: 'Normalized version string (v-prefix stripped)'
+        description: "Normalized version string (v-prefix stripped)"
         value: ${{ jobs.build.outputs.normalized_version }}
 
 jobs:

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -13,12 +13,12 @@ on:
         description: 'CMake configure preset'
         type: string
         required: false
-        default: 'vs2022-windows-vcpkg'
+        default: 'vs2022-ninja-windows-vcpkg'
       build-preset:
         description: 'CMake build preset'
         type: string
         required: false
-        default: 'Release'
+        default: 'Release-Ninja'
       version:
         description: 'Version string for the build'
         type: string

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -19,8 +19,11 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Install clang-format
+        run: pip install clang-format==22.1.5 # keep in sync with .pre-commit-config.yaml
+
       - name: Run clang-format
-        run: find -type f \( -name *.h -o -name *.cpp \) | xargs clang-format-16 -style=file -i
+        run: find -type f \( -name *.h -o -name *.cpp \) | xargs clang-format -style=file -i
 
       - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -10,18 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'alandtse'
     permissions:
-      contents: write   # git-auto-commit pushes the formatting commit
+      contents: write # git-auto-commit pushes the formatting commit
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: '3.9'
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.9"
 
-    - name: Run clang-format
-      run: find -type f \( -name *.h -o -name *.cpp \) | xargs clang-format-16 -style=file -i
+      - name: Run clang-format
+        run: find -type f \( -name *.h -o -name *.cpp \) | xargs clang-format-16 -style=file -i
 
-    - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
-      with:
-        commit_message: "style: maintenance"
+      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+        with:
+          commit_message: "style: maintenance"

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -19,11 +19,12 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Install clang-format
-        run: pip install clang-format==22.1.5 # keep in sync with .pre-commit-config.yaml
+      - name: Install pre-commit
+        run: pip install pre-commit
 
       - name: Run clang-format
-        run: find -type f \( -name *.h -o -name *.cpp \) | xargs clang-format -style=file -i
+        run: pre-commit run --all-files clang-format --show-diff-on-failure
+        continue-on-error: true # formats in place; git-auto-commit-action below commits any changes
 
       - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -26,6 +26,6 @@ jobs:
     name: Test Build
     uses: ./.github/workflows/build-reusable.yml
     with:
-      configure-preset: vs2022-windows-vcpkg
-      build-preset: Release
+      configure-preset: vs2022-ninja-windows-vcpkg
+      build-preset: Release-Ninja
       upload-artifact: false

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -4,22 +4,22 @@ on:
   pull_request:
     paths:
       # Source files
-      - 'src/**/*.cpp'
-      - 'src/**/*.h'
-      - 'src/**/*.hpp'
+      - "src/**/*.cpp"
+      - "src/**/*.h"
+      - "src/**/*.hpp"
       # Build configuration
-      - 'CMakeLists.txt'
-      - 'cmake/**'
-      - 'CMakePresets.json'
+      - "CMakeLists.txt"
+      - "cmake/**"
+      - "CMakePresets.json"
       # Dependencies
-      - 'vcpkg.json'
-      - '.gitmodules'
-      - 'external/**'
+      - "vcpkg.json"
+      - ".gitmodules"
+      - "external/**"
       # Build scripts
-      - 'scripts/**'
+      - "scripts/**"
       # CI workflows that affect build
-      - '.github/workflows/build-reusable.yml'
-      - '.github/workflows/pr-test.yml'
+      - ".github/workflows/build-reusable.yml"
+      - ".github/workflows/pr-test.yml"
 
 jobs:
   test-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,8 @@ jobs:
       (needs.semantic-release.outputs.new_release_published == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/build-reusable.yml
     with:
-      configure-preset: vs2022-windows-vcpkg
-      build-preset: Release
+      configure-preset: vs2022-ninja-windows-vcpkg
+      build-preset: Release-Ninja
       version: ${{ needs.semantic-release.outputs.new_release_version || inputs.version }}
       upload-artifact: true
       ref: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to upload to Nexus (leave empty for latest release)'
+        description: "Version to upload to Nexus (leave empty for latest release)"
         type: string
         required: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,16 +13,31 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.6
+    rev: v22.1.5
     hooks:
       - id: clang-format
         types_or: [c++, c]
         args: [--style=file]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        files: |
+          (?x)^(
+            \.github/|
+            .*\.(ya?ml|md|json)$
+          )
+        exclude: |
+          (?x)^(
+            build/|
+            external/
+          )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,8 @@ ci:
 
     Applied by pre-commit.ci
   autofix_prs: true
-  autoupdate_branch: ''
-  autoupdate_commit_msg: 'ci(deps): update pre-commit hooks'
+  autoupdate_branch: ""
+  autoupdate_commit_msg: "ci(deps): update pre-commit hooks"
   autoupdate_schedule: weekly
   skip: []
   submodules: false

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -52,11 +52,7 @@
         "CMAKE_CXX_FLAGS": "/EHsc /MP /W4 /WX /external:anglebrackets /external:W0"
       },
       "generator": "Visual Studio 16 2019",
-      "inherits": [
-        "cmake-dev",
-        "vcpkg",
-        "windows"
-      ],
+      "inherits": ["cmake-dev", "vcpkg", "windows"],
       "name": "vs2019-windows-vcpkg"
     },
     {
@@ -68,23 +64,13 @@
     },
     {
       "generator": "Visual Studio 17 2022",
-      "inherits": [
-        "vs2022-flags",
-        "cmake-dev",
-        "vcpkg",
-        "windows"
-      ],
+      "inherits": ["vs2022-flags", "cmake-dev", "vcpkg", "windows"],
       "name": "vs2022-windows-vcpkg",
       "toolset": "v143"
     },
     {
       "generator": "Ninja",
-      "inherits": [
-        "vs2022-flags",
-        "cmake-dev",
-        "vcpkg",
-        "windows"
-      ],
+      "inherits": ["vs2022-flags", "cmake-dev", "vcpkg", "windows"],
       "description": "Uses CMake's automatic MSVC toolchain detection, so it works from a plain shell (no vcvars64.bat needed) and on CI runners where the 'Visual Studio 17 2022' generator can fail to locate a VS instance.",
       "name": "vs2022-ninja-windows-vcpkg"
     }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -78,17 +78,6 @@
       "toolset": "v143"
     },
     {
-      "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "cl"
-      },
-      "architecture": {
-        "strategy": "external",
-        "value": "x64"
-      },
-      "toolset": {
-        "strategy": "external",
-        "value": "v143,host=x64"
-      },
       "generator": "Ninja",
       "inherits": [
         "vs2022-flags",
@@ -96,7 +85,7 @@
         "vcpkg",
         "windows"
       ],
-      "description": "If you are running CMake from the command line and not from an IDE, make sure to run 'vcvars64.bat' first. The default installed location of this is 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat'.",
+      "description": "Uses CMake's automatic MSVC toolchain detection, so it works from a plain shell (no vcvars64.bat needed) and on CI runners where the 'Visual Studio 17 2022' generator can fail to locate a VS instance.",
       "name": "vs2022-ninja-windows-vcpkg"
     }
   ],
@@ -104,6 +93,11 @@
     {
       "name": "Release",
       "configurePreset": "vs2022-windows-vcpkg",
+      "configuration": "Release"
+    },
+    {
+      "name": "Release-Ninja",
+      "configurePreset": "vs2022-ninja-windows-vcpkg",
       "configuration": "Release"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -43,15 +43,9 @@ git submodule init
 git submodule update
 ```
 
-### Fallout 4
 ```
-cmake --preset vs2022-windows-vcpkg
-cmake --build build --config Release
-```
-### VR
-```
-cmake --preset vs2022-windows-vcpkg-vr
-cmake --build buildvr --config Release
+cmake --preset vs2022-ninja-windows-vcpkg
+cmake --build build --preset Release-Ninja
 ```
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -2,38 +2,41 @@
 
 It's like buffout but for the engine. This is a fork for VR.
 
-* [Fallout4](https://www.nexusmods.com/fallout4/mods/47359)
-* [Fallout4 VR](https://www.nexusmods.com/fallout4/mods/64880)
+- [Fallout4](https://www.nexusmods.com/fallout4/mods/47359)
+- [Fallout4 VR](https://www.nexusmods.com/fallout4/mods/64880)
 
 # Build Dependencies
-* [AutoTOML](https://github.com/Ryan-rsm-McKenzie/AutoTOML)
-* [Boost](https://www.boost.org/)
-	* Algorithm
-	* Container
-	* Nowide
-	* Stacktrace
-* [CommonLibF4](https://github.com/Ryan-rsm-McKenzie/CommonLibF4)
-* [CommonLibF4 VR enabled](https://github.com/alandtse/CommonLibF4)
-	* Add this as as an environment variable `CommonLibF4Path` or use the submodule in /external
-* [fmt](https://github.com/fmtlib/fmt)
-* [Frozen](https://github.com/serge-sans-paille/frozen)
-* [infoware](https://github.com/ThePhD/infoware)
-* [mmio](https://github.com/Ryan-rsm-McKenzie/mmio)
-* [rsm-binary-io](https://github.com/Ryan-rsm-McKenzie/binary_io)
-* [robin-hood-hashing](https://github.com/martinus/robin-hood-hashing)
-* [spdlog](https://github.com/gabime/spdlog)
-* [TBB](https://github.com/oneapi-src/oneTBB)
-* [Xbyak](https://github.com/herumi/xbyak)
+
+- [AutoTOML](https://github.com/Ryan-rsm-McKenzie/AutoTOML)
+- [Boost](https://www.boost.org/)
+  - Algorithm
+  - Container
+  - Nowide
+  - Stacktrace
+- [CommonLibF4](https://github.com/Ryan-rsm-McKenzie/CommonLibF4)
+- [CommonLibF4 VR enabled](https://github.com/alandtse/CommonLibF4)
+  - Add this as as an environment variable `CommonLibF4Path` or use the submodule in /external
+- [fmt](https://github.com/fmtlib/fmt)
+- [Frozen](https://github.com/serge-sans-paille/frozen)
+- [infoware](https://github.com/ThePhD/infoware)
+- [mmio](https://github.com/Ryan-rsm-McKenzie/mmio)
+- [rsm-binary-io](https://github.com/Ryan-rsm-McKenzie/binary_io)
+- [robin-hood-hashing](https://github.com/martinus/robin-hood-hashing)
+- [spdlog](https://github.com/gabime/spdlog)
+- [TBB](https://github.com/oneapi-src/oneTBB)
+- [Xbyak](https://github.com/herumi/xbyak)
 
 # End User Dependencies
-* [Address Library for F4SE Plugins](https://www.nexusmods.com/fallout4/mods/47327)
-* [VR Address Library for F4SEVR](https://www.nexusmods.com/fallout4/mods/64879)
-* [F4SE](https://f4se.silverlock.org/)
-* [F4SEVR](https://f4se.silverlock.org/)
-* [Microsoft Visual C++ Redistributable for Visual Studio 2019](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
-* [TBB](https://github.com/oneapi-src/oneTBB/releases/latest)
+
+- [Address Library for F4SE Plugins](https://www.nexusmods.com/fallout4/mods/47327)
+- [VR Address Library for F4SEVR](https://www.nexusmods.com/fallout4/mods/64879)
+- [F4SE](https://f4se.silverlock.org/)
+- [F4SEVR](https://f4se.silverlock.org/)
+- [Microsoft Visual C++ Redistributable for Visual Studio 2019](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
+- [TBB](https://github.com/oneapi-src/oneTBB/releases/latest)
 
 # Building
+
 ```
 git clone https://github.com/alandtse/Buffout4.git
 cd Buffout4
@@ -49,17 +52,19 @@ cmake --build build --preset Release-Ninja
 ```
 
 # Credits
-* [Ryan-rsm-Mckenzie](https://github.com/Ryan-rsm-McKenzie) - Original code and framework and for enabling the commonlib community in Skyrim and Fallout
-* PDB requires `msdia140.dll` distributed under [Visual Studio C++ Redistributable](https://docs.microsoft.com/en-us/visualstudio/releases/2022/redistribution#dia-sdk). [PDB Handler](src/Crash/PDB/PdbHandler.cpp) derived from StackOverflow code.
+
+- [Ryan-rsm-Mckenzie](https://github.com/Ryan-rsm-McKenzie) - Original code and framework and for enabling the commonlib community in Skyrim and Fallout
+- PDB requires `msdia140.dll` distributed under [Visual Studio C++ Redistributable](https://docs.microsoft.com/en-us/visualstudio/releases/2022/redistribution#dia-sdk). [PDB Handler](src/Crash/PDB/PdbHandler.cpp) derived from StackOverflow code.
 
 # License
+
 [GPL-3.0-or-later](LICENSE) WITH [Modding Exception AND GPL-3.0 Linking Exception (with Corresponding Source)](EXCEPTIONS.md).
 
 Specifically, the Modded Code includes:
 
-* Fallout 4 (and its variants, including Fallout 4 VR)
+- Fallout 4 (and its variants, including Fallout 4 VR)
 
 The Modding Libraries include:
 
-* [F4SE / F4SEVR](https://f4se.silverlock.org/)
-* CommonLibF4 (and variants)
+- [F4SE / F4SEVR](https://f4se.silverlock.org/)
+- CommonLibF4 (and variants)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 It's like buffout but for the engine. This is a fork for VR.
 
-- [Fallout4](https://www.nexusmods.com/fallout4/mods/47359)
-- [Fallout4 VR](https://www.nexusmods.com/fallout4/mods/64880)
+- [Fallout 4](https://www.nexusmods.com/fallout4/mods/47359)
+- [Fallout 4 VR](https://www.nexusmods.com/fallout4/mods/64880)
 
 # Build Dependencies
 
@@ -15,7 +15,7 @@ It's like buffout but for the engine. This is a fork for VR.
   - Stacktrace
 - [CommonLibF4](https://github.com/Ryan-rsm-McKenzie/CommonLibF4)
 - [CommonLibF4 VR enabled](https://github.com/alandtse/CommonLibF4)
-  - Add this as as an environment variable `CommonLibF4Path` or use the submodule in /external
+  - Add this as an environment variable `CommonLibF4Path` or use the submodule in /external
 - [fmt](https://github.com/fmtlib/fmt)
 - [Frozen](https://github.com/serge-sans-paille/frozen)
 - [infoware](https://github.com/ThePhD/infoware)
@@ -48,7 +48,7 @@ git submodule update
 
 ```
 cmake --preset vs2022-ninja-windows-vcpkg
-cmake --build build --preset Release-Ninja
+cmake --build --preset Release-Ninja
 ```
 
 # Credits

--- a/src/Patches/WorkshopMenuPatch.h
+++ b/src/Patches/WorkshopMenuPatch.h
@@ -464,7 +464,7 @@ namespace Patches::WorkshopMenuPatch
 			switch (a_cobj.createdItem->GetFormType()) {
 			case RE::ENUM_FORM_ID::kFLST:
 				for (const auto& flst = static_cast<RE::BGSListForm&>(*a_cobj.createdItem);
-					const auto form : flst.arrayOfForms) {
+					 const auto form : flst.arrayOfForms) {
 					make(form).sourceFormListRecipe = &a_cobj;
 				}
 				break;

--- a/src/Patches/WorkshopMenuPatch.h
+++ b/src/Patches/WorkshopMenuPatch.h
@@ -464,7 +464,7 @@ namespace Patches::WorkshopMenuPatch
 			switch (a_cobj.createdItem->GetFormType()) {
 			case RE::ENUM_FORM_ID::kFLST:
 				for (const auto& flst = static_cast<RE::BGSListForm&>(*a_cobj.createdItem);
-					 const auto form : flst.arrayOfForms) {
+					const auto form : flst.arrayOfForms) {
 					make(form).sourceFormListRecipe = &a_cobj;
 				}
 				break;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,9 +13,7 @@
     "frozen",
     {
       "name": "infoware",
-      "features": [
-        "d3d"
-      ]
+      "features": ["d3d"]
     },
     "magic-enum",
     "nowide",


### PR DESCRIPTION
## Summary
- `Test Build` was failing on every PR (e.g. #42): `CMake Error ... Generator "Visual Studio 17 2022" ... could not find any instance of Visual Studio`. `windows-latest`'s runner image rolled between 2026-07-25 and 2026-07-28 and broke CMake's VS-generator vswhere lookup.
- Switches CI (`pr-test.yml`, `release.yml`, `build-reusable.yml` defaults) to the existing `vs2022-ninja-windows-vcpkg` preset, stripped of its old forced `CXX_COMPILER=cl`/toolset overrides so it relies on CMake's automatic MSVC detection - same pattern already proven stable on `CrashLoggerSSE`'s CI over this same window.
- Bumps stale `.pre-commit-config.yaml` hook pins (`clang-format` v16->v22, `pre-commit-hooks` v4->v6) and adds `prettier` for yaml/md/json, matching current sibling repos.
- Updates README build instructions to match (drops a stale `vs2022-windows-vcpkg-vr` preset reference that no longer exists).

## Test plan
- [ ] `Test Build` / `PR Test Build` check passes on this PR
- [ ] Local `cmake --preset vs2022-ninja-windows-vcpkg` configures without `vcvars64.bat` pre-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qnfj2DML4RGxFb3MaRyzb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build Improvements**
  - Updated Windows builds and releases to use the Ninja generator with the Release-Ninja configuration.
  - Added the Release-Ninja build preset for more consistent build automation.

- **Documentation**
  - Simplified and updated build instructions to reflect the Ninja-based workflow.
  - Reformatted dependency, credits, and license sections for improved readability.

- **Maintenance**
  - Updated formatting tools and automated checks, including newer ClangFormat and Prettier support.
  - Added the Direct3D feature requirement for the Infoware dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->